### PR TITLE
fix mypy failing with Mount and routes parameter

### DIFF
--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -295,7 +295,7 @@ class Mount(BaseRoute):
         self,
         path: str,
         app: ASGIApp = None,
-        routes: typing.List[BaseRoute] = None,
+        routes: typing.Sequence[BaseRoute] = None,
         name: str = None,
     ) -> None:
         assert path == "" or path.startswith("/"), "Routed paths must start with '/'"


### PR DESCRIPTION
Currently, mypy fails with the following error when Starlette is initialized with a mount in routes.

```
app = Starlette(
    routes=[
        Mount('api', routes=routes)
    ]
)
```

mypy fails with the following:
```
app/main.py:24: error: Argument "routes" to "Mount" has incompatible type "List[Route]"; expected "Optional[List[BaseRoute]]"
app/main.py:24: note: "List" is invariant -- see http://mypy.readthedocs.io/en/latest/common_issues.html#variance
app/main.py:24: note: Consider using "Sequence" instead, which is covariant
```

This change also brings `Mount` types into alignment with `Router`